### PR TITLE
Provision of additional installation options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,19 +117,19 @@ tarball: MANIFEST
 	(cd ..; xargs tar -czvf vulcan-dev/$(TARBALL) < vulcan-dev/MANIFEST)
 	(cd ..; rm vulcan-$(VERSION))
 
-install: $(TARGET) chessmodels
+installdirs: mkinstalldirs
+	./mkinstalldirs -m 755 $(PREFIX) $(BIN) $(PREFIX)/share \
+	$(DATA_DIR) $(FONT_DIR) $(MODEL_DIR) $(TEXTURE_DIR)
+
+install: $(TARGET) chessmodels installdirs
 	install -s -m 755 $(TARGET) $(BIN)
-	install -m 755 -d $(DATA_DIR)
-	install -m 755 -d $(FONT_DIR)
 	cp data/fonts/* $(FONT_DIR)
 	chmod 644 $(FONT_DIR)/*
-	install -m 755 -d $(MODEL_DIR)
 	./chessmodels > $(MODEL_DIR)/chess-models.modeldef
 	chmod 644 $(MODEL_DIR)/*
-	install -m 755 -d $(TEXTURE_DIR)
 	cp data/textures/* $(TEXTURE_DIR)
 	chmod 644 $(TEXTURE_DIR)/*
 
-distclean:
+uninstall:
 	rm -f $(BIN)/$(TARGET)
 	rm -fr $(DATA_DIR)

--- a/README
+++ b/README
@@ -11,12 +11,23 @@ INSTALLING
 You need OpenGL and X libraries and header files installed.  As of version 0.5,
 you also need libpng.
 
-As the superuser, run `make install'.
 
-The data files will be installed at /usr/local/share/vulcan, and the game
-binary will be installed at /usr/local/bin/vulcan. If you wish to change this
+To install system-wide, either
+	run `make' and then run `sudo make install',
+or
+	as the superuser, run `make install'.
+
+The data files will be installed in /usr/local/share/vulcan, and the game
+binary 'vulcan' will be installed in /usr/local/bin. If you wish to change this
 configuration, edit the Makefile and change the variables PREFIX, BIN, and
 DATA_DIR (at the beginning of the file).
+
+
+Alternatively, to install in the current user account,
+run `make PREFIX=~/.vulcan install'.
+
+In this case, the data files will be installed in ~/.vulcan/share/vulcan,
+and the game binary 'vulcan' will be installed in ~/.vulcan/bin.
 
 
 RUNNING

--- a/mkinstalldirs
+++ b/mkinstalldirs
@@ -1,0 +1,162 @@
+#! /bin/sh
+# mkinstalldirs --- make directory hierarchy
+
+scriptversion=2016-01-11.22; # UTC
+
+# Original author: Noah Friedman <friedman@prep.ai.mit.edu>
+# Created: 1993-05-16
+# Public domain.
+#
+# This file is maintained in Automake, please report
+# bugs to <bug-automake@gnu.org> or send patches to
+# <automake-patches@gnu.org>.
+
+nl='
+'
+IFS=" ""	$nl"
+errstatus=0
+dirmode=
+
+usage="\
+Usage: mkinstalldirs [-h] [--help] [--version] [-m MODE] DIR ...
+
+Create each directory DIR (with mode MODE, if specified), including all
+leading file name components.
+
+Report bugs to <bug-automake@gnu.org>."
+
+# process command line arguments
+while test $# -gt 0 ; do
+  case $1 in
+    -h | --help | --h*)         # -h for help
+      echo "$usage"
+      exit $?
+      ;;
+    -m)                         # -m PERM arg
+      shift
+      test $# -eq 0 && { echo "$usage" 1>&2; exit 1; }
+      dirmode=$1
+      shift
+      ;;
+    --version)
+      echo "$0 $scriptversion"
+      exit $?
+      ;;
+    --)                         # stop option processing
+      shift
+      break
+      ;;
+    -*)                         # unknown option
+      echo "$usage" 1>&2
+      exit 1
+      ;;
+    *)                          # first non-opt arg
+      break
+      ;;
+  esac
+done
+
+for file
+do
+  if test -d "$file"; then
+    shift
+  else
+    break
+  fi
+done
+
+case $# in
+  0) exit 0 ;;
+esac
+
+# Solaris 8's mkdir -p isn't thread-safe.  If you mkdir -p a/b and
+# mkdir -p a/c at the same time, both will detect that a is missing,
+# one will create a, then the other will try to create a and die with
+# a "File exists" error.  This is a problem when calling mkinstalldirs
+# from a parallel make.  We use --version in the probe to restrict
+# ourselves to GNU mkdir, which is thread-safe.
+case $dirmode in
+  '')
+    if mkdir -p --version . >/dev/null 2>&1 && test ! -d ./--version; then
+      echo "mkdir -p -- $*"
+      exec mkdir -p -- "$@"
+    else
+      # On NextStep and OpenStep, the 'mkdir' command does not
+      # recognize any option.  It will interpret all options as
+      # directories to create, and then abort because '.' already
+      # exists.
+      test -d ./-p && rmdir ./-p
+      test -d ./--version && rmdir ./--version
+    fi
+    ;;
+  *)
+    if mkdir -m "$dirmode" -p --version . >/dev/null 2>&1 &&
+       test ! -d ./--version; then
+      echo "mkdir -m $dirmode -p -- $*"
+      exec mkdir -m "$dirmode" -p -- "$@"
+    else
+      # Clean up after NextStep and OpenStep mkdir.
+      for d in ./-m ./-p ./--version "./$dirmode";
+      do
+        test -d $d && rmdir $d
+      done
+    fi
+    ;;
+esac
+
+for file
+do
+  case $file in
+    /*) pathcomp=/ ;;
+    *)  pathcomp= ;;
+  esac
+  oIFS=$IFS
+  IFS=/
+  set fnord $file
+  shift
+  IFS=$oIFS
+
+  for d
+  do
+    test "x$d" = x && continue
+
+    pathcomp=$pathcomp$d
+    case $pathcomp in
+      -*) pathcomp=./$pathcomp ;;
+    esac
+
+    if test ! -d "$pathcomp"; then
+      echo "mkdir $pathcomp"
+
+      mkdir "$pathcomp" || lasterr=$?
+
+      if test ! -d "$pathcomp"; then
+	errstatus=$lasterr
+      else
+	if test ! -z "$dirmode"; then
+	  echo "chmod $dirmode $pathcomp"
+	  lasterr=
+	  chmod "$dirmode" "$pathcomp" || lasterr=$?
+
+	  if test ! -z "$lasterr"; then
+	    errstatus=$lasterr
+	  fi
+	fi
+      fi
+    fi
+
+    pathcomp=$pathcomp/
+  done
+done
+
+exit $errstatus
+
+# Local Variables:
+# mode: shell-script
+# sh-indentation: 2
+# eval: (add-hook 'write-file-hooks 'time-stamp)
+# time-stamp-start: "scriptversion="
+# time-stamp-format: "%:y-%02m-%02d.%02H"
+# time-stamp-time-zone: "UTC0"
+# time-stamp-end: "; # UTC"
+# End:


### PR DESCRIPTION
@mpersano 

Mauro,
This request provide information and changes to facilitate safer make/install methods.  What do ya think?
1. Makefile
   - Moved directory creation to _installdirs_ target to enable both checking for directory existence and directory creation as needed using the _mkinstalldirs_ script.  This facilitates installation in a user account, where standard _bin_ and _share_ directories don't exist.
   - Changed target _distclean_ to _uninstall_ to conform with standard target usage: [Standard Targets for Users](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html).
2. README
   - Added descriptions for safer system-wide installation (make in user space, followed by install in root space) and for installation in a user account.
3. mkinstalldirs
   - This public domain script from the Gnulib package facilitates checking if directories exist and creating them if necessary.  See the _installdirs_ target section toward the end of [Standard Targets for Users](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html).

Thanks!
David
